### PR TITLE
Add Vim to the list of known editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,14 @@ Download the `open-in-editor` file from this repo and make it executable.
 
 Ensure that one of the environment variables `OPEN_IN_EDITOR` or `EDITOR` contains a path to an executable that `open-in-editor` is going to recognize. This environment variable must be set system-wide, not just in your shell process. For example, in MacOS, one does this with `launchctl setenv EDITOR /path/to/my/editor/executable`.
 
-`open-in-editor` looks for any of the following substrings in the path: `emacsclient` (emacs), `subl` (sublime), `charm` (pycharm), `code` (vscode). For example, any of the following values would work:
+`open-in-editor` looks for any of the following substrings in the path: `emacsclient` (emacs), `subl` (sublime), `charm` (pycharm), `code` (vscode) or `vim` (vim). For example, any of the following values would work:
 
 - `/usr/local/bin/emacsclient`
 - `/usr/local/bin/charm`
 - `/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl`
 - `/usr/local/bin/code`
+- `/usr/bin/vim`
+- `/usr/local/bin/nvim`
 
 If your editor/IDE isn't supported, then please open an issue. If your editor/IDE is supported, but the above logic needs to be made more sophisticated, then either (a) open an issue, or (b) create a symlink that complies with the above rules.
 

--- a/open-in-editor
+++ b/open-in-editor
@@ -100,6 +100,8 @@ class BaseEditor(object):
             sub_cls = PyCharm
         elif "code" in executable_path:
             sub_cls = VSCode
+        elif "vim" in executable_path:
+            sub_cls = Vim
         else:
             log(
                 "ERROR: failed to infer your editor. "
@@ -157,6 +159,13 @@ class Sublime(BaseEditor):
 class VSCode(BaseEditor):
     def visit_file(self, path, line):
         cmd = [self.executable, "-g", "%s:%s" % (path, line)]
+        log(" ".join(cmd))
+        subprocess.check_call(cmd)
+
+
+class Vim(BaseEditor):
+    def visit_file(self, path, line):
+        cmd = [self.executable, "+%s" % str(line), path]
         log(" ".join(cmd))
         subprocess.check_call(cmd)
 


### PR DESCRIPTION
Also works with the  GUI version of Vim (GVim) as well as NeoVim, since
all their binaries contain `vim` as a substring.

I think it's unlikely to cause any future problems.  At least I haven't
come across any other (non vim-compatible) editors which have a `*vim*`
executable. :D