### PR TITLE
Use the column part of URIs (first off, vim only)

### DIFF
--- a/OpenInEditor.app/Contents/Resources/script
+++ b/OpenInEditor.app/Contents/Resources/script
@@ -22,9 +22,9 @@ def main():
     try:
         editor = BaseEditor.infer_from_environment_variables()
         (url,) = sys.argv[1:]
-        path, line, _ = parse_url(url)
-        log("path=%s line=%s" % (path, line))
-        editor.visit_file(path, line or 1)
+        path, line, column = parse_url(url)
+        log("path=%s line=%s column=%s" % (path, line, column))
+        editor.visit_file(path, line or 1, column or 1)
     except Exception:
         from traceback import format_exc
 
@@ -117,12 +117,12 @@ class BaseEditor(object):
     def __init__(self, executable):
         self.executable = executable
 
-    def visit_file(self, path, line):
+    def visit_file(self, path, line, column):
         raise NotImplementedError()
 
 
 class Emacs(BaseEditor):
-    def visit_file(self, path, line):
+    def visit_file(self, path, line, column):
         cmd = [
             self.executable,
             "--no-wait",
@@ -143,29 +143,30 @@ class Emacs(BaseEditor):
 
 
 class PyCharm(BaseEditor):
-    def visit_file(self, path, line):
+    def visit_file(self, path, line, column):
         cmd = [self.executable, "--line", str(line), path]
         log(" ".join(cmd))
         subprocess.check_call([s.encode("utf-8") for s in cmd])
 
 
 class Sublime(BaseEditor):
-    def visit_file(self, path, line):
+    def visit_file(self, path, line, column):
         cmd = [self.executable, "%s:%s" % (path, line)]
         log(" ".join(cmd))
         subprocess.check_call(cmd)
 
 
 class VSCode(BaseEditor):
-    def visit_file(self, path, line):
+    def visit_file(self, path, line, column):
         cmd = [self.executable, "-g", "%s:%s" % (path, line)]
         log(" ".join(cmd))
         subprocess.check_call(cmd)
 
 
 class Vim(BaseEditor):
-    def visit_file(self, path, line):
-        cmd = [self.executable, "+%s" % str(line), path]
+    def visit_file(self, path, line, column):
+        cmd = [self.executable, "+%s" % str(line)]
+        cmd.extend(["-c", "normal %sl" % str(column - 1), path] if column > 1 else [path])
         log(" ".join(cmd))
         subprocess.check_call(cmd)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Open a local file from a URL at a line number in an editor/IDE.
 
 The idea is that you would register this application as a handler for certain URLs in your system.
 
-The URL must be structured like a [file URL](https://en.wikipedia.org/wiki/File_URI_scheme), but it may optionally have a `:<line>:<column>` suffix. If the line is present, the editor will open the file at that line. (Column is ignored currently.)
+The URL must be structured like a [file URL](https://en.wikipedia.org/wiki/File_URI_scheme), but it may optionally have a `:<line>:<column>` suffix. If the line is present, the editor will open the file at that line. (Column is currently only implemented for vim.)
 
 The URL scheme (protocol) is ignored. For example, you could use standard `file://` URLs, or you could use a custom URL scheme that only exists in your system. In either case, you must register `open-in-editor` (or the provided MacOS application) with your OS as the handler for that URL scheme.
 

--- a/open-in-editor
+++ b/open-in-editor
@@ -22,9 +22,9 @@ def main():
     try:
         editor = BaseEditor.infer_from_environment_variables()
         (url,) = sys.argv[1:]
-        path, line, _ = parse_url(url)
-        log("path=%s line=%s" % (path, line))
-        editor.visit_file(path, line or 1)
+        path, line, column = parse_url(url)
+        log("path=%s line=%s column=%s" % (path, line, column))
+        editor.visit_file(path, line or 1, column or 1)
     except Exception:
         from traceback import format_exc
 
@@ -117,12 +117,12 @@ class BaseEditor(object):
     def __init__(self, executable):
         self.executable = executable
 
-    def visit_file(self, path, line):
+    def visit_file(self, path, line, column):
         raise NotImplementedError()
 
 
 class Emacs(BaseEditor):
-    def visit_file(self, path, line):
+    def visit_file(self, path, line, column):
         cmd = [
             self.executable,
             "--no-wait",
@@ -143,29 +143,30 @@ class Emacs(BaseEditor):
 
 
 class PyCharm(BaseEditor):
-    def visit_file(self, path, line):
+    def visit_file(self, path, line, column):
         cmd = [self.executable, "--line", str(line), path]
         log(" ".join(cmd))
         subprocess.check_call([s.encode("utf-8") for s in cmd])
 
 
 class Sublime(BaseEditor):
-    def visit_file(self, path, line):
+    def visit_file(self, path, line, column):
         cmd = [self.executable, "%s:%s" % (path, line)]
         log(" ".join(cmd))
         subprocess.check_call(cmd)
 
 
 class VSCode(BaseEditor):
-    def visit_file(self, path, line):
+    def visit_file(self, path, line, column):
         cmd = [self.executable, "-g", "%s:%s" % (path, line)]
         log(" ".join(cmd))
         subprocess.check_call(cmd)
 
 
 class Vim(BaseEditor):
-    def visit_file(self, path, line):
-        cmd = [self.executable, "+%s" % str(line), path]
+    def visit_file(self, path, line, column):
+        cmd = [self.executable, "+%s" % str(line)]
+        cmd.extend(["-c", "normal %sl" % str(column - 1), path] if column > 1 else [path])
         log(" ".join(cmd))
         subprocess.check_call(cmd)
 


### PR DESCRIPTION
This implements the usage  of the optional `column` element of open-in-
editor URIs if vim (or a derivative) is the configured editor.

This feature shouldn't be hard to add to the other classes once we have
figured out these editors' according command line syntaxes.

Btw, I haven't missed to also adjust the `script` file accordingly this
time. ;)