### PR TITLE
Copy script to MacOS app

### DIFF
--- a/OpenInEditor.app/Contents/Resources/script
+++ b/OpenInEditor.app/Contents/Resources/script
@@ -102,6 +102,8 @@ class BaseEditor(object):
             sub_cls = VSCode
         elif "vim" in executable_path:
             sub_cls = Vim
+        elif "o" in executable_path:
+            sub_cls = O
         else:
             log(
                 "ERROR: failed to infer your editor. "
@@ -167,6 +169,13 @@ class Vim(BaseEditor):
     def visit_file(self, path, line, column):
         cmd = [self.executable, "+%s" % str(line)]
         cmd.extend(["-c", "normal %sl" % str(column - 1), path] if column > 1 else [path])
+        log(" ".join(cmd))
+        subprocess.check_call(cmd)
+
+
+class O(BaseEditor):
+    def visit_file(self, path, line, column):
+        cmd = [self.executable, path, "+%s" % str(line), "+%s" % str(column)]
         log(" ".join(cmd))
         subprocess.check_call(cmd)
 


### PR DESCRIPTION
It looks like the MacOS script got out of date with the addition of "O" support.

I wish I had a better idea for keeping them in sync, but I don't :shrug: Git has native support for symbolic links, but making either `open-in-editor` or `OpenInEditor.app/Contents/Resources/script` a symbolic link would make it harder to just copy one of those in place and have it "just work".