### PR TITLE
Support column in VS Code

### DIFF
--- a/OpenInEditor.app/Contents/Resources/script
+++ b/OpenInEditor.app/Contents/Resources/script
@@ -160,7 +160,7 @@ class Sublime(BaseEditor):
 
 class VSCode(BaseEditor):
     def visit_file(self, path, line, column):
-        cmd = [self.executable, "-g", "%s:%s" % (path, line)]
+        cmd = [self.executable, "-g", "%s:%s:%s" % (path, line, column)]
         log(" ".join(cmd))
         subprocess.check_call(cmd)
 

--- a/open-in-editor
+++ b/open-in-editor
@@ -160,7 +160,7 @@ class Sublime(BaseEditor):
 
 class VSCode(BaseEditor):
     def visit_file(self, path, line, column):
-        cmd = [self.executable, "-g", "%s:%s" % (path, line)]
+        cmd = [self.executable, "-g", "%s:%s:%s" % (path, line, column)]
         log(" ".join(cmd))
         subprocess.check_call(cmd)
 


### PR DESCRIPTION
Add support for `file:line:column` in VS Code

Not sure since when this is supported, both `code -h` and the [documentation](https://code.visualstudio.com/docs/editor/command-line#_core-cli-options) claims it is.

Tested with VS Code 1.58 on Linux, with `open-in-editor` setup according to the README.