### PR TITLE
feat: add column support for Sublime Text

### DIFF
--- a/OpenInEditor.app/Contents/Resources/script
+++ b/OpenInEditor.app/Contents/Resources/script
@@ -153,7 +153,7 @@ class PyCharm(BaseEditor):
 
 class Sublime(BaseEditor):
     def visit_file(self, path, line, column):
-        cmd = [self.executable, "%s:%s" % (path, line)]
+        cmd = [self.executable, "%s:%s:%s" % (path, line, column)]
         log(" ".join(cmd))
         subprocess.check_call(cmd)
 

--- a/open-in-editor
+++ b/open-in-editor
@@ -153,7 +153,7 @@ class PyCharm(BaseEditor):
 
 class Sublime(BaseEditor):
     def visit_file(self, path, line, column):
-        cmd = [self.executable, "%s:%s" % (path, line)]
+        cmd = [self.executable, "%s:%s:%s" % (path, line, column)]
         log(" ".join(cmd))
         subprocess.check_call(cmd)
 


### PR DESCRIPTION
Sublime Text's `subl` command also supports columns

>Filenames may be given a :line or :line:column suffix to open at a specific
location.
