### PR TITLE
allow clean cask uninstall

### DIFF
--- a/casks/open-in-editor.rb
+++ b/casks/open-in-editor.rb
@@ -17,4 +17,9 @@ cask "open-in-editor" do
   }
 
   uninstall quit: bundle_id
+
+  zap trash: [
+    "~/Library/Saved Application State/org.dandavison.OpenInEditor.savedState",
+    "~/Library/Caches/org.dandavison.OpenInEditor",
+  ]
 end


### PR DESCRIPTION
Adds zap paths to enable full cleanup on uninstallation with `--zap` flag

By the way, I've noticed that your tap already has the bundle, so when installing the cask you install the bundle twice.
No big deal, but might make sense to move the brew tap to a separate repo, so it only has the instructions re. how to install