### PR TITLE
feat: add Helix text editor support

### DIFF
--- a/OpenInEditor.app/Contents/Resources/script
+++ b/OpenInEditor.app/Contents/Resources/script
@@ -105,6 +105,8 @@ class BaseEditor(object):
             sub_cls = VSCode
         elif "vim" in executable_path:
             sub_cls = Vim
+        elif "hx" in executable_path:
+            sub_cls = Helix
         elif "o" in executable_path:
             sub_cls = O
         else:
@@ -172,6 +174,13 @@ class Vim(BaseEditor):
     def visit_file(self, path, line, column):
         cmd = [self.executable, "+%s" % str(line)]
         cmd.extend(["-c", "normal %sl" % str(column - 1), path] if column > 1 else [path])
+        log_debug(" ".join(cmd))
+        subprocess.check_call(cmd)
+
+
+class Helix(BaseEditor):
+    def visit_file(self, path, line, column):
+        cmd = [self.executable, "%s:%s:%s" % (path, line, column)]
         log_debug(" ".join(cmd))
         subprocess.check_call(cmd)
 

--- a/open-in-editor
+++ b/open-in-editor
@@ -105,6 +105,8 @@ class BaseEditor(object):
             sub_cls = VSCode
         elif "vim" in executable_path:
             sub_cls = Vim
+        elif "hx" in executable_path:
+            sub_cls = Helix
         elif "o" in executable_path:
             sub_cls = O
         else:
@@ -172,6 +174,13 @@ class Vim(BaseEditor):
     def visit_file(self, path, line, column):
         cmd = [self.executable, "+%s" % str(line)]
         cmd.extend(["-c", "normal %sl" % str(column - 1), path] if column > 1 else [path])
+        log_debug(" ".join(cmd))
+        subprocess.check_call(cmd)
+
+
+class Helix(BaseEditor):
+    def visit_file(self, path, line, column):
+        cmd = [self.executable, "%s:%s:%s" % (path, line, column)]
         log_debug(" ".join(cmd))
         subprocess.check_call(cmd)
 


### PR DESCRIPTION
By the way, is the relaxed matching of executables (`"code" in executable_path` instead of `executable_path.endswith("code")`) intentional?
I've encountered this issue when I've added this editor at the end, but then the `o` condition (is this some catch-all editor?) interfered since path had `o` in it