### PR TITLE
Add more specific tests for which editor is in env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/

--- a/OpenInEditor.app/Contents/Resources/script
+++ b/OpenInEditor.app/Contents/Resources/script
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: UTF-8 -*-
 """
 This code is all in one file, and supports Python 2, in order that it can be wrapped conveniently
 as a MacOS application bundle (e.g. using https://github.com/sveinbjornt/Platypus).
@@ -82,42 +83,22 @@ class BaseEditor(object):
     """
 
     @classmethod
-    def infer_from_environment_variables(cls):
+    def infer_editor_from_path(cls, path):
         """
-        Infer the editor type and its executable path heuristically from environment variables.
+        Infer the editor type and its executable path heuristically
         """
-        OPEN_IN_EDITOR, EDITOR = os.getenv("OPEN_IN_EDITOR"), os.getenv("EDITOR")
-        executable_path_with_arguments_maybe = OPEN_IN_EDITOR or EDITOR
-        try:
-            arguments_start = executable_path_with_arguments_maybe.index(" -")
-        except ValueError:
-            executable_path = executable_path_with_arguments_maybe
-        else:
-            executable_path = executable_path_with_arguments_maybe[:arguments_start+1]
+        # 'Apps/VS Code - In.app/app/bin/code -arg'
+        # ↓ up to last /     = '/Apps/VS Code - In.app/app/bin'
+        path_head, path_tail = os.path.split(path)
+        # after the last / ↑ = 'code -arg'
+        path_bin = path_tail.split(' -')[0].strip() # remove ' -args' = 'code'
+        path_head = path_head + os.sep if path_head else path_head # add / back if it existed
+        executable_path = path_head + path_bin
 
-        editor_classes = {
-          "emacsclient" : Emacs,
-          "subl"        : Sublime,
-          "charm"       : PyCharm,
-          "code"        : VSCode,
-          "vim"         : Vim,
-          "hx"          : Helix,
-          "o"           : O,
-        }
-        sub_cls = None
-        if sub_cls is None: # match if editor path ends with the name of the editor
-            for bin_,class_ in editor_classes.items():
-                if executable_path.rstrip().endswith(bin_):
-                    sub_cls = class_
-        if sub_cls is None: # or if 'editor_bin_name ' is in editor path
-            for bin_,class_ in editor_classes.items():
-                if bin_ + ' ' in executable_path:
-                    sub_cls = class_
-        if sub_cls is None: # or if 'editor_bin_name'  is in editor path
-            for bin_,class_ in editor_classes.items():
-                if bin_       in executable_path.rstrip():
-                    sub_cls = class_
-        if sub_cls is None:
+        editors = [Emacs, Sublime, PyCharm, VSCode, Vim, Helix, O]
+
+        inferred_editor = next((ed for ed in editors if path_bin == ed.executable_name), None)
+        if inferred_editor is None:
             log_error(
                 "ERROR: failed to infer your editor. "
                 "The values of the relevant environment variables are: "
@@ -127,7 +108,17 @@ class BaseEditor(object):
                 % (OPEN_IN_EDITOR, EDITOR)
             )
             sys.exit(1)
-        return sub_cls(executable_path.rstrip())
+        return inferred_editor(executable_path)
+
+    @classmethod
+    def infer_from_environment_variables(cls):
+        """
+        Infer the editor type and its executable path heuristically from environment variables.
+        """
+        OPEN_IN_EDITOR, EDITOR = os.getenv("OPEN_IN_EDITOR"), os.getenv("EDITOR")
+        executable_path_with_arguments_maybe = OPEN_IN_EDITOR or EDITOR
+
+        return cls.infer_editor_from_path(executable_path_with_arguments_maybe)
 
     def __init__(self, executable):
         self.executable = executable
@@ -137,6 +128,7 @@ class BaseEditor(object):
 
 
 class Emacs(BaseEditor):
+    executable_name = 'emacsclient'
     def visit_file(self, path, line, column):
         cmd = [
             self.executable,
@@ -158,6 +150,7 @@ class Emacs(BaseEditor):
 
 
 class PyCharm(BaseEditor):
+    executable_name = 'charm'
     def visit_file(self, path, line, column):
         cmd = [self.executable, "--line", str(line), path]
         log_debug(" ".join(cmd))
@@ -165,6 +158,7 @@ class PyCharm(BaseEditor):
 
 
 class Sublime(BaseEditor):
+    executable_name = 'subl'
     def visit_file(self, path, line, column):
         cmd = [self.executable, "%s:%s:%s" % (path, line, column)]
         log_debug(" ".join(cmd))
@@ -172,6 +166,7 @@ class Sublime(BaseEditor):
 
 
 class VSCode(BaseEditor):
+    executable_name = 'code'
     def visit_file(self, path, line, column):
         cmd = [self.executable, "-g", "%s:%s:%s" % (path, line, column)]
         log_debug(" ".join(cmd))
@@ -179,6 +174,7 @@ class VSCode(BaseEditor):
 
 
 class Vim(BaseEditor):
+    executable_name = 'vim'
     def visit_file(self, path, line, column):
         cmd = [self.executable, "+%s" % str(line)]
         cmd.extend(["-c", "normal %sl" % str(column - 1), path] if column > 1 else [path])
@@ -187,6 +183,7 @@ class Vim(BaseEditor):
 
 
 class Helix(BaseEditor):
+    executable_name = 'hx'
     def visit_file(self, path, line, column):
         cmd = [self.executable, "%s:%s:%s" % (path, line, column)]
         log_debug(" ".join(cmd))
@@ -194,6 +191,7 @@ class Helix(BaseEditor):
 
 
 class O(BaseEditor):
+    executable_name = 'o'
     def visit_file(self, path, line, column):
         cmd = [self.executable, path, "+%s" % str(line), "+%s" % str(column)]
         log_debug(" ".join(cmd))

--- a/OpenInEditor.app/Contents/Resources/script
+++ b/OpenInEditor.app/Contents/Resources/script
@@ -93,23 +93,31 @@ class BaseEditor(object):
         except ValueError:
             executable_path = executable_path_with_arguments_maybe
         else:
-            executable_path = executable_path_with_arguments_maybe[:arguments_start].rstrip()
+            executable_path = executable_path_with_arguments_maybe[:arguments_start+1]
 
-        if "emacsclient" in executable_path:
-            sub_cls = Emacs
-        elif "subl" in executable_path:
-            sub_cls = Sublime
-        elif "charm" in executable_path:
-            sub_cls = PyCharm
-        elif "code" in executable_path:
-            sub_cls = VSCode
-        elif "vim" in executable_path:
-            sub_cls = Vim
-        elif "hx" in executable_path:
-            sub_cls = Helix
-        elif "o" in executable_path:
-            sub_cls = O
-        else:
+        editor_classes = {
+          "emacsclient" : Emacs,
+          "subl"        : Sublime,
+          "charm"       : PyCharm,
+          "code"        : VSCode,
+          "vim"         : Vim,
+          "hx"          : Helix,
+          "o"           : O,
+        }
+        sub_cls = None
+        if sub_cls is None: # match if editor path ends with the name of the editor
+            for bin_,class_ in editor_classes.items():
+                if executable_path.rstrip().endswith(bin_):
+                    sub_cls = class_
+        if sub_cls is None: # or if 'editor_bin_name ' is in editor path
+            for bin_,class_ in editor_classes.items():
+                if bin_ + ' ' in executable_path:
+                    sub_cls = class_
+        if sub_cls is None: # or if 'editor_bin_name'  is in editor path
+            for bin_,class_ in editor_classes.items():
+                if bin_       in executable_path.rstrip():
+                    sub_cls = class_
+        if sub_cls is None:
             log_error(
                 "ERROR: failed to infer your editor. "
                 "The values of the relevant environment variables are: "
@@ -119,7 +127,7 @@ class BaseEditor(object):
                 % (OPEN_IN_EDITOR, EDITOR)
             )
             sys.exit(1)
-        return sub_cls(executable_path)
+        return sub_cls(executable_path.rstrip())
 
     def __init__(self, executable):
         self.executable = executable

--- a/open-in-editor
+++ b/open-in-editor
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: UTF-8 -*-
 """
 This code is all in one file, and supports Python 2, in order that it can be wrapped conveniently
 as a MacOS application bundle (e.g. using https://github.com/sveinbjornt/Platypus).
@@ -88,28 +89,18 @@ class BaseEditor(object):
         """
         OPEN_IN_EDITOR, EDITOR = os.getenv("OPEN_IN_EDITOR"), os.getenv("EDITOR")
         executable_path_with_arguments_maybe = OPEN_IN_EDITOR or EDITOR
-        try:
-            arguments_start = executable_path_with_arguments_maybe.index(" -")
-        except ValueError:
-            executable_path = executable_path_with_arguments_maybe
-        else:
-            executable_path = executable_path_with_arguments_maybe[:arguments_start].rstrip()
+        # 'Apps/VS Code - In.app/app/bin/code -arg'
+        # ↓ up to last /     = '/Apps/VS Code - In.app/app/bin'
+        path_head, path_tail = os.path.split(executable_path_with_arguments_maybe)
+        # after the last / ↑ = 'code -arg'
+        path_bin = path_tail.split(' -')[0].strip() # remove ' -args' = 'code'
+        path_head = path_head + os.sep if path_head else path_head # add / back if it existed
+        executable_path = path_head + path_bin
 
-        if "emacsclient" in executable_path:
-            sub_cls = Emacs
-        elif "subl" in executable_path:
-            sub_cls = Sublime
-        elif "charm" in executable_path:
-            sub_cls = PyCharm
-        elif "code" in executable_path:
-            sub_cls = VSCode
-        elif "vim" in executable_path:
-            sub_cls = Vim
-        elif "hx" in executable_path:
-            sub_cls = Helix
-        elif "o" in executable_path:
-            sub_cls = O
-        else:
+        editors = [Emacs, Sublime, PyCharm, VSCode, Vim, Helix, O]
+
+        inferred_editor = next((ed for ed in editors if path_bin == ed.executable_name), None)
+        if inferred_editor is None:
             log_error(
                 "ERROR: failed to infer your editor. "
                 "The values of the relevant environment variables are: "
@@ -119,7 +110,7 @@ class BaseEditor(object):
                 % (OPEN_IN_EDITOR, EDITOR)
             )
             sys.exit(1)
-        return sub_cls(executable_path)
+        return inferred_editor(executable_path)
 
     def __init__(self, executable):
         self.executable = executable
@@ -129,6 +120,7 @@ class BaseEditor(object):
 
 
 class Emacs(BaseEditor):
+    executable_name = 'emacsclient'
     def visit_file(self, path, line, column):
         cmd = [
             self.executable,
@@ -150,6 +142,7 @@ class Emacs(BaseEditor):
 
 
 class PyCharm(BaseEditor):
+    executable_name = 'charm'
     def visit_file(self, path, line, column):
         cmd = [self.executable, "--line", str(line), path]
         log_debug(" ".join(cmd))
@@ -157,6 +150,7 @@ class PyCharm(BaseEditor):
 
 
 class Sublime(BaseEditor):
+    executable_name = 'subl'
     def visit_file(self, path, line, column):
         cmd = [self.executable, "%s:%s:%s" % (path, line, column)]
         log_debug(" ".join(cmd))
@@ -164,6 +158,7 @@ class Sublime(BaseEditor):
 
 
 class VSCode(BaseEditor):
+    executable_name = 'code'
     def visit_file(self, path, line, column):
         cmd = [self.executable, "-g", "%s:%s:%s" % (path, line, column)]
         log_debug(" ".join(cmd))
@@ -171,6 +166,7 @@ class VSCode(BaseEditor):
 
 
 class Vim(BaseEditor):
+    executable_name = 'vim'
     def visit_file(self, path, line, column):
         cmd = [self.executable, "+%s" % str(line)]
         cmd.extend(["-c", "normal %sl" % str(column - 1), path] if column > 1 else [path])
@@ -179,6 +175,7 @@ class Vim(BaseEditor):
 
 
 class Helix(BaseEditor):
+    executable_name = 'hx'
     def visit_file(self, path, line, column):
         cmd = [self.executable, "%s:%s:%s" % (path, line, column)]
         log_debug(" ".join(cmd))
@@ -186,6 +183,7 @@ class Helix(BaseEditor):
 
 
 class O(BaseEditor):
+    executable_name = 'o'
     def visit_file(self, path, line, column):
         cmd = [self.executable, path, "+%s" % str(line), "+%s" % str(column)]
         log_debug(" ".join(cmd))

--- a/open-in-editor
+++ b/open-in-editor
@@ -83,15 +83,13 @@ class BaseEditor(object):
     """
 
     @classmethod
-    def infer_from_environment_variables(cls):
+    def infer_editor_from_path(cls, path):
         """
-        Infer the editor type and its executable path heuristically from environment variables.
+        Infer the editor type and its executable path heuristically
         """
-        OPEN_IN_EDITOR, EDITOR = os.getenv("OPEN_IN_EDITOR"), os.getenv("EDITOR")
-        executable_path_with_arguments_maybe = OPEN_IN_EDITOR or EDITOR
         # 'Apps/VS Code - In.app/app/bin/code -arg'
         # ↓ up to last /     = '/Apps/VS Code - In.app/app/bin'
-        path_head, path_tail = os.path.split(executable_path_with_arguments_maybe)
+        path_head, path_tail = os.path.split(path)
         # after the last / ↑ = 'code -arg'
         path_bin = path_tail.split(' -')[0].strip() # remove ' -args' = 'code'
         path_head = path_head + os.sep if path_head else path_head # add / back if it existed
@@ -111,6 +109,16 @@ class BaseEditor(object):
             )
             sys.exit(1)
         return inferred_editor(executable_path)
+
+    @classmethod
+    def infer_from_environment_variables(cls):
+        """
+        Infer the editor type and its executable path heuristically from environment variables.
+        """
+        OPEN_IN_EDITOR, EDITOR = os.getenv("OPEN_IN_EDITOR"), os.getenv("EDITOR")
+        executable_path_with_arguments_maybe = OPEN_IN_EDITOR or EDITOR
+
+        return cls.infer_editor_from_path(executable_path_with_arguments_maybe)
 
     def __init__(self, executable):
         self.executable = executable

--- a/test/editor_detection.py
+++ b/test/editor_detection.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import inspect
+import importlib.util
+from importlib.machinery import SourceFileLoader
+
+curdir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+pardir = os.path.dirname(curdir)
+sys.path.insert(0, pardir)
+
+
+def import_from_file(module_name, file_path):
+  loader = SourceFileLoader(module_name, file_path)
+  spec   = importlib.util.spec_from_file_location(module_name, loader=loader)
+  module = importlib.util.module_from_spec(spec)
+  sys.modules[module_name] = module
+  spec.loader.exec_module(module)
+
+  return module
+
+open_in_editor = import_from_file('open-in-editor', 'open-in-editor')
+be = open_in_editor.BaseEditor
+
+def test_editor_detection():
+  test_paths = {
+  '/Applications/Visual Studio Code - Insiders.app/Contents/Resources/app/bin/code'	:'code',
+  '/App/Vis Stu Code -   In.app/app  /bin/code   -g'                               	:'code',
+  R'C:\Program Files\Visual Studio Code - Insiders/app/bin/code  - u'              	:'code',
+  '/opt/local/bin/hx'                                                              	:'hx',
+  'subl   -w'                                                                      	:'subl',
+  '/usr/bin/vim   -u'                                                              	:'vim',
+  '    vim      -a -b -c'                                                          	:'vim',
+  }
+  for path_,bin_ in test_paths.items():
+    assert be.infer_editor_from_path(path_).executable_name == bin_


### PR DESCRIPTION
Avoids greedily-matching for a presence of a letter `o` in a `/opt/local/bin/vim` because there is this nice editor named **O**
The old checks remain, just have less of a priority