### PR TITLE
Log at error and info level by default

### DIFF
--- a/OpenInEditor.app/Contents/Resources/script
+++ b/OpenInEditor.app/Contents/Resources/script
@@ -23,7 +23,7 @@ def main():
         editor = BaseEditor.infer_from_environment_variables()
         (url,) = sys.argv[1:]
         path, line, column = parse_url(url)
-        log_debug("path=%s line=%s column=%s" % (path, line, column))
+        log_info("path=%s line=%s column=%s" % (path, line, column))
         editor.visit_file(path, line or 1, column or 1)
     except Exception:
         from traceback import format_exc
@@ -64,7 +64,7 @@ def parse_url(url):  # type: (str) -> (str, Optional[int], Optional[int]):
     return path, line, column
 
 
-def log_error(line):
+def log(line):
     time = datetime.datetime.now().isoformat(" ").split(".")[0]
     with open(LOGFILE, "a") as fp:
         print(time, file=fp)
@@ -72,9 +72,8 @@ def log_error(line):
         print("\n", file=fp)
         fp.flush()
 
-def log_debug(line):
-    pass
-
+log_info = log
+log_error = log
 
 class BaseEditor(object):
     """
@@ -145,28 +144,28 @@ class Emacs(BaseEditor):
             "(when (functionp 'pulse-momentary-highlight-one-line)"
             " (let ((pulse-delay 0.05)) (pulse-momentary-highlight-one-line (point) 'highlight)))",
         ]
-        log_debug(" ".join(cmd))
+        log_info(" ".join(cmd))
         subprocess.check_call(cmd)
 
 
 class PyCharm(BaseEditor):
     def visit_file(self, path, line, column):
         cmd = [self.executable, "--line", str(line), path]
-        log_debug(" ".join(cmd))
+        log_info(" ".join(cmd))
         subprocess.check_call([s.encode("utf-8") for s in cmd])
 
 
 class Sublime(BaseEditor):
     def visit_file(self, path, line, column):
         cmd = [self.executable, "%s:%s:%s" % (path, line, column)]
-        log_debug(" ".join(cmd))
+        log_info(" ".join(cmd))
         subprocess.check_call(cmd)
 
 
 class VSCode(BaseEditor):
     def visit_file(self, path, line, column):
         cmd = [self.executable, "-g", "%s:%s:%s" % (path, line, column)]
-        log_debug(" ".join(cmd))
+        log_info(" ".join(cmd))
         subprocess.check_call(cmd)
 
 
@@ -174,21 +173,21 @@ class Vim(BaseEditor):
     def visit_file(self, path, line, column):
         cmd = [self.executable, "+%s" % str(line)]
         cmd.extend(["-c", "normal %sl" % str(column - 1), path] if column > 1 else [path])
-        log_debug(" ".join(cmd))
+        log_info(" ".join(cmd))
         subprocess.check_call(cmd)
 
 
 class Helix(BaseEditor):
     def visit_file(self, path, line, column):
         cmd = [self.executable, "%s:%s:%s" % (path, line, column)]
-        log_debug(" ".join(cmd))
+        log_info(" ".join(cmd))
         subprocess.check_call(cmd)
 
 
 class O(BaseEditor):
     def visit_file(self, path, line, column):
         cmd = [self.executable, path, "+%s" % str(line), "+%s" % str(column)]
-        log_debug(" ".join(cmd))
+        log_info(" ".join(cmd))
         subprocess.check_call(cmd)
 
 

--- a/open-in-editor
+++ b/open-in-editor
@@ -23,7 +23,7 @@ def main():
         editor = BaseEditor.infer_from_environment_variables()
         (url,) = sys.argv[1:]
         path, line, column = parse_url(url)
-        log_debug("path=%s line=%s column=%s" % (path, line, column))
+        log_info("path=%s line=%s column=%s" % (path, line, column))
         editor.visit_file(path, line or 1, column or 1)
     except Exception:
         from traceback import format_exc
@@ -64,7 +64,7 @@ def parse_url(url):  # type: (str) -> (str, Optional[int], Optional[int]):
     return path, line, column
 
 
-def log_error(line):
+def log(line):
     time = datetime.datetime.now().isoformat(" ").split(".")[0]
     with open(LOGFILE, "a") as fp:
         print(time, file=fp)
@@ -72,9 +72,8 @@ def log_error(line):
         print("\n", file=fp)
         fp.flush()
 
-def log_debug(line):
-    pass
-
+log_info = log
+log_error = log
 
 class BaseEditor(object):
     """
@@ -145,28 +144,28 @@ class Emacs(BaseEditor):
             "(when (functionp 'pulse-momentary-highlight-one-line)"
             " (let ((pulse-delay 0.05)) (pulse-momentary-highlight-one-line (point) 'highlight)))",
         ]
-        log_debug(" ".join(cmd))
+        log_info(" ".join(cmd))
         subprocess.check_call(cmd)
 
 
 class PyCharm(BaseEditor):
     def visit_file(self, path, line, column):
         cmd = [self.executable, "--line", str(line), path]
-        log_debug(" ".join(cmd))
+        log_info(" ".join(cmd))
         subprocess.check_call([s.encode("utf-8") for s in cmd])
 
 
 class Sublime(BaseEditor):
     def visit_file(self, path, line, column):
         cmd = [self.executable, "%s:%s:%s" % (path, line, column)]
-        log_debug(" ".join(cmd))
+        log_info(" ".join(cmd))
         subprocess.check_call(cmd)
 
 
 class VSCode(BaseEditor):
     def visit_file(self, path, line, column):
         cmd = [self.executable, "-g", "%s:%s:%s" % (path, line, column)]
-        log_debug(" ".join(cmd))
+        log_info(" ".join(cmd))
         subprocess.check_call(cmd)
 
 
@@ -174,21 +173,21 @@ class Vim(BaseEditor):
     def visit_file(self, path, line, column):
         cmd = [self.executable, "+%s" % str(line)]
         cmd.extend(["-c", "normal %sl" % str(column - 1), path] if column > 1 else [path])
-        log_debug(" ".join(cmd))
+        log_info(" ".join(cmd))
         subprocess.check_call(cmd)
 
 
 class Helix(BaseEditor):
     def visit_file(self, path, line, column):
         cmd = [self.executable, "%s:%s:%s" % (path, line, column)]
-        log_debug(" ".join(cmd))
+        log_info(" ".join(cmd))
         subprocess.check_call(cmd)
 
 
 class O(BaseEditor):
     def visit_file(self, path, line, column):
         cmd = [self.executable, path, "+%s" % str(line), "+%s" % str(column)]
-        log_debug(" ".join(cmd))
+        log_info(" ".join(cmd))
         subprocess.check_call(cmd)
 
 


### PR DESCRIPTION
cc @eugenesvk the info-level logging by default was deliberate and I would like to keep it.

Commit message:

It's very annoying to debug this since it's not running in a terminal, and it involves obscure OS mechanisms that hardly anyone's familiar with. Having the info-level logging output present by default makes it easy to determine, when it's not working, whether the script was ever invoked by the URL handler.