### PR TITLE
fix: unquote URLs passed to GUI app

### DIFF
--- a/OpenInEditor.app/Contents/Resources/script
+++ b/OpenInEditor.app/Contents/Resources/script
@@ -11,10 +11,11 @@ import subprocess
 import sys
 
 try:
-    from urllib.parse import urlparse
+    from urllib.parse import urlparse, unquote
 except ImportError:
     # Python 2
     from urlparse import urlparse
+    from urllib   import unquote
 
 LOGFILE        = "/tmp/open-in-editor.log"
 OPEN_IN_EDITOR = os.getenv("OPEN_IN_EDITOR")
@@ -53,7 +54,7 @@ def parse_url(url):  # type: (str) -> (str, Optional[int], Optional[int]):
     >>> parse_url("file://localhost/a/b/myfile.txt:7:77")
     ('/a/b/myfile.txt', 7, 77)
     """
-    path, _, line_and_column = urlparse(url).path.partition(":")
+    path, _, line_and_column = urlparse(unquote(url)).path.partition(":")
     line, _, column = line_and_column.partition(":")
     try:
         line = int(line)

--- a/test/url_parse.py
+++ b/test/url_parse.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import inspect
+import importlib.util
+from importlib.machinery import SourceFileLoader
+
+curdir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+pardir = os.path.dirname(curdir)
+sys.path.insert(0, pardir)
+
+
+def import_from_file(module_name, file_path):
+  loader = SourceFileLoader(module_name, file_path)
+  spec   = importlib.util.spec_from_file_location(module_name, loader=loader)
+  module = importlib.util.module_from_spec(spec)
+  sys.modules[module_name] = module
+  spec.loader.exec_module(module)
+
+  return module
+
+open_in_editor = import_from_file('open-in-editor', 'OpenInEditor.app/Contents/Resources/script')
+parse_url = open_in_editor.parse_url
+
+def test_editor_detection():
+  test_urls = {
+  'a%20b.txt'	:'a b.txt',
+  }
+  for url_escaped,url_raw in test_urls.items():
+    assert parse_url(url_escaped)[0] == url_raw


### PR DESCRIPTION
NB! **cli** and **gui** scripts are now **different** as cli shouldn't be escaped in case actual file names contain those `%20` characters literally, the terminal doesn't autoescape it

Close https://github.com/dandavison/open-in-editor/issues/23